### PR TITLE
make snap installable even with non-standard gadget

### DIFF
--- a/snap/hooks/connect-plug-serial-port
+++ b/snap/hooks/connect-plug-serial-port
@@ -1,0 +1,17 @@
+#! /bin/sh
+
+# we need the interface connected before enabling the daemon, 
+# else the snap is not manually installable on non-standard gadgets
+if ! snapctl is-connected serial-port; then
+	echo "please run 'snap connect ${SNAP_NAME}:serial-port <gadget-name>:<serial-port>"
+	echo "keeping services disabled for the moment"
+	exit 0
+fi
+
+# now we can start the btuart and bthelper services
+if snapctl services ${SNAP_NAME}.btuart | grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.btuart 2>&1 || true
+fi
+if snapctl services ${SNAP_NAME}.bthelper| grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.bthelper 2>&1 || true
+fi

--- a/snap/hooks/connect-plug-serial-port
+++ b/snap/hooks/connect-plug-serial-port
@@ -1,14 +1,6 @@
 #! /bin/sh
 
-# we need the interface connected before enabling the daemon, 
-# else the snap is not manually installable on non-standard gadgets
-if ! snapctl is-connected serial-port; then
-	echo "please run 'snap connect ${SNAP_NAME}:serial-port <gadget-name>:<serial-port>"
-	echo "keeping services disabled for the moment"
-	exit 0
-fi
-
-# now we can start the btuart and bthelper services
+# serial-port is connected, now we can start the btuart and bthelper services
 if snapctl services ${SNAP_NAME}.btuart | grep -q inactive; then
   snapctl start --enable ${SNAP_NAME}.btuart 2>&1 || true
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
   btuart:
     command: bin/btuart
     daemon: forking
+    install-mode: disable
     plugs:
       - serial-port
       - hardware-observe
@@ -21,6 +22,7 @@ apps:
   bthelper:
     command: bin/bthelper
     daemon: oneshot
+    install-mode: disable
     after:
       - btuart
     plugs:


### PR DESCRIPTION
When using a non default gadget (i.e. locally built or in a brand store), the snap-declaration from the store does not apply and the serial-port interface does not get connected ... when the interface is not connected, the daemons do not start and exit non-zero, this makes snapd completely remove the snap again (which results in an unbootable image)... 

to make pi-bluetooth installable in such a situation, the daemons should be disabled at the point of installation and then get enabled by a connect hook for the serial-port, this makes sure they only try to run when the required connection is actually there.